### PR TITLE
(fix) Fix mailer crashing server on bill split submittal

### DIFF
--- a/server/utils/mailer.js
+++ b/server/utils/mailer.js
@@ -43,7 +43,6 @@ export default function mailSender(app, express, rootDir) {
             res.send('There was an error sending the email');
             return;
           }
-          res.send('Email Sent');
         });
       }
       
@@ -67,7 +66,6 @@ export default function mailSender(app, express, rootDir) {
         res.send('There was an error sending the email');
         return;
       }
-      res.send('Email Sent');
     });
   });
 


### PR DESCRIPTION
Removed 'res.send()' instances in mailer functions.